### PR TITLE
Script for generating videos with numbered frames

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+/number-frames/
+/number-videos/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,3 +88,28 @@ Different sets of codecs can be tested by modifying the list in the script.
 ``` bash
 ./ffmpeg-transcoding-benchmark.sh Beach.mp4 /tmp/output
 ```
+
+### Generating syntnetic videos using various codecs and containters
+#### generate-number-videos.sh
+Usage:
+```
+./generate-number-videos.sh <num_frames> <gop_size>
+```
+
+Uses ImageMagick to generate a PNG image sequence consisting of `<num_frames>` images with subsequent numbers, starting at 1.
+Then uses the images as input for `ffmpeg` to generate 25 FPS videos without audio track.
+
+`<gop_size>` is the size of a single [Group of Pictues](https://en.wikipedia.org/wiki/Group_of_pictures) in the resulting video.
+A GOP always starts with an I-frame so setting a lower value ensures that there are enough I-frames to make splitting a video into more segments possible without transcoding.
+The default value is 25.
+Note that not all codecs respect this value.
+
+The set of codecs and containers is hard-coded in the script.
+They were chosen arbitrarily, based on what `ffmpeg -codecs` and `ffmpeg -formats` report, but with emphasis on more popular combinations, with some less popular ones sprinkled in.
+
+The script leaves numbered frames in `number-frames/` and videos in `number-videos/`.
+
+#### Examples
+``` bash
+./generate-number-videos.sh 10000 25
+```

--- a/scripts/generate-number-videos.sh
+++ b/scripts/generate-number-videos.sh
@@ -46,14 +46,65 @@ echo "Generating $num_frames number frames"
 # NOTE: The H.263 codec supports only a few specific resolutions. 352x288 is one of them.
 for i in $(seq 1 "$num_frames"); do
     generate_frame default $i 128 128
+    generate_frame h261    $i 352 288   # Resolutions supported by h261:             176x144, 352x288
+    generate_frame h263    $i 352 288   # Resolutions supported by h263:     128x96, 176x144, 352x288,   704x576, 1408x1152
+    generate_frame dvvideo $i 720 576   # Resolutions supported by dvvideo: 720x480, 720x576, 960x720, 1280x1080, 1440x1080
 done
 
-generate_number_video default flv1       flv
-generate_number_video h263    h263       3gp
-generate_number_video default h264       mp4
-generate_number_video default mpeg4      mpeg
-generate_number_video default theora     ogv
-generate_number_video default vp9        webm
+# Tier 1: popular codecs
+generate_number_video default av1        mkv   # Alliance for Open Media AV1
+generate_number_video default cinepak    cpk   # Cinepak
+generate_number_video default dirac      drc   # Dirac
+generate_number_video default dirac      mkv
+generate_number_video default dirac      mp4
+generate_number_video default dirac      avi
+generate_number_video default flv1       flv   # FLV / Sorenson Spark / Sorenson H.263 (Flash Video)
+generate_number_video default flv1       mkv
+generate_number_video default flv1       avi
+generate_number_video h263    h263       3gp   # H.263 / H.263-1996, H.263+ / H.263-1998 / H.263 version 2
+generate_number_video h263    h263       h263
+generate_number_video default h264       mp4   # H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
+generate_number_video default h264       h264
+generate_number_video default h264       mkv
+generate_number_video default h264       avi
+generate_number_video default h264       flv
+generate_number_video default hevc       mp4   # H.265 / HEVC (High Efficiency Video Coding)
+generate_number_video default hevc       mkv
+generate_number_video default hevc       hevc
+generate_number_video default hevc       mpeg
+generate_number_video default mjpeg      mjpeg # Motion JPEG
+generate_number_video default mjpeg      avi
+generate_number_video default mjpeg      mov
+generate_number_video default mjpeg      mkv
+generate_number_video default mpeg1video mpeg  # MPEG-1 video
+generate_number_video default mpeg1video m1v
+generate_number_video default mpeg2video mpeg  # MPEG-2 video
+generate_number_video default mpeg4      mpeg  # MPEG-4 part 2
+generate_number_video default mpeg4      mp4
+generate_number_video default theora     ogv   # Theora
+generate_number_video default theora     mkv
+generate_number_video default vp8        webm  # On2 VP8
+generate_number_video default vp8        ivf
+generate_number_video default vp9        webm  # Google VP9
 generate_number_video default vp9        mp4
-generate_number_video default wmv2       asf
+generate_number_video default vp9        avi
+generate_number_video default wmv1       asf   # Windows Media Video 7
+generate_number_video default wmv2       asf   # Windows Media Video 8
 
+# Tier 2: some less popular codecs
+generate_number_video dvvideo dvvideo    dv    # DV (Digital Video)
+generate_number_video h261    h261       h261  # H.261
+generate_number_video h263    h263p      h263  # H.263+ / H.263-1998 / H.263 version 2
+generate_number_video default huffyuv    mkv   # HuffYUV
+generate_number_video default msmpeg4v2  mpeg  # MPEG-4 part 2 Microsoft variant version 2
+generate_number_video default msmpeg4v3  mpeg  # MPEG-4 part 2 Microsoft variant version 3
+generate_number_video default rawvideo   mkv   # raw video
+generate_number_video default rv10       rm    # RealVideo 1.0
+generate_number_video default rv20       rm    # RealVideo 2.0
+generate_number_video default svq1       mov   # Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
+generate_number_video default v210       avi   # Uncompressed 4:2:2 10-bit
+generate_number_video default v308       avi   # Uncompressed packed 4:4:4
+generate_number_video default v408       avi   # Uncompressed packed QT 4:4:4:4
+generate_number_video default v410       avi   # Uncompressed 4:4:4 10-bit
+generate_number_video default y41p       avi   # Uncompressed YUV 4:1:1 12-bit
+generate_number_video default yuv4       avi   # Uncompressed packed 4:2:0

--- a/scripts/generate-number-videos.sh
+++ b/scripts/generate-number-videos.sh
@@ -4,6 +4,7 @@ mkdir --parents number-frames/
 mkdir --parents number-videos/
 
 num_frames="$1"
+gop_size=25
 
 function generate_frame {
     local frame_prefix="$1"
@@ -30,19 +31,19 @@ function generate_number_video {
     local codec="$2"
     local format="$3"
 
-    echo "Generating number-videos/numbers-$num_frames-$codec.$format"
+    echo "Generating number-videos/numbers-$num_frames-gop-$gop_size-$codec.$format"
 
     ffmpeg                                                       \
         -nostdin                                                 \
         -v      error                                            \
         -i      "number-frames/$frame_prefix-$num_frames-%d.png" \
         -vcodec "$codec"                                         \
-        -g      25                                               \
+        -g      "$gop_size"                                      \
         -strict -2                                               \
-        "number-videos/numbers-$num_frames-$codec.$format"
+        "number-videos/numbers-$num_frames-gop-$gop_size-$codec.$format"
 }
 
-echo "Generating $num_frames number frames"
+echo "Generating $num_frames number frames with GOP size $gop_size"
 
 # NOTE: The H.263 codec supports only a few specific resolutions. 352x288 is one of them.
 for i in $(seq 1 "$num_frames"); do

--- a/scripts/generate-number-videos.sh
+++ b/scripts/generate-number-videos.sh
@@ -5,40 +5,55 @@ mkdir --parents number-videos/
 
 num_frames="$1"
 
+function generate_frame {
+    local frame_prefix="$1"
+    local frame_number="$2"
+    local width="$3"
+    local height="$4"
+
+    local dimensions=${width}x${height}
+    local font_size=$(( height / 2 ))
+
+    convert                     \
+        -gravity    Center      \
+        -background blue        \
+        -fill       white       \
+        -pointsize  $font_size  \
+        label:$frame_number     \
+        -extent     $dimensions \
+        -quality    100         \
+        "number-frames/$frame_prefix-$num_frames-$frame_number.png"
+}
+
+function generate_number_video {
+    local frame_prefix="$1"
+    local codec="$2"
+    local format="$3"
+
+    echo "Generating number-videos/numbers-$num_frames-$codec.$format"
+
+    ffmpeg                                                       \
+        -nostdin                                                 \
+        -v      error                                            \
+        -i      "number-frames/$frame_prefix-$num_frames-%d.png" \
+        -vcodec "$codec"                                         \
+        -strict -2                                               \
+        "number-videos/numbers-$num_frames-$codec.$format"
+}
+
 echo "Generating $num_frames number frames"
 
 # NOTE: The H.263 codec supports only a few specific resolutions. 352x288 is one of them.
 for i in $(seq 1 "$num_frames"); do
-    convert                 \
-        -gravity    Center  \
-        -background blue    \
-        -fill       white   \
-        -pointsize  200     \
-        label:$i            \
-        -extent     352x288 \
-        -quality    100     \
-        "number-frames/$num_frames-$i.png"
+    generate_frame default $i 352 288
 done
 
-function generate_number_video {
-    local codec="$1"
-    local format="$2"
+generate_number_video default flv1       flv
+generate_number_video h263    h263       3gp
+generate_number_video default h264       mp4
+generate_number_video default mpeg4      mpeg
+generate_number_video default theora     ogv
+generate_number_video default vp9        webm
+generate_number_video default vp9        mp4
+generate_number_video default wmv2       asf
 
-    echo "Generating number-videos/numbers-$num_frames-$codec.$format"
-
-    ffmpeg                                     \
-        -nostdin                               \
-        -v error                               \
-        -i "number-frames/$num_frames-%d.png"  \
-        -vcodec "$codec"                       \
-        "number-videos/numbers-$num_frames-$codec.$format"
-}
-
-generate_number_video vp9    mp4
-generate_number_video theora ogv
-generate_number_video flv1   flv
-generate_number_video mpeg4  mpeg
-generate_number_video h264   mp4
-generate_number_video vp9    webm
-generate_number_video wmv2   asf
-generate_number_video h263   3gp

--- a/scripts/generate-number-videos.sh
+++ b/scripts/generate-number-videos.sh
@@ -1,0 +1,44 @@
+#!/bin/bash -e
+
+mkdir --parents number-frames/
+mkdir --parents number-videos/
+
+num_frames=100
+
+echo "Generating $num_frames number frames"
+
+# NOTE: The H.263 codec supports only a few specific resolutions. 352x288 is one of them.
+for i in $(seq 1 "$num_frames"); do
+    convert                 \
+        -gravity    Center  \
+        -background blue    \
+        -fill       white   \
+        -pointsize  200     \
+        label:$i            \
+        -extent     352x288 \
+        -quality    100     \
+        "number-frames/$num_frames-$i.png"
+done
+
+function generate_number_video {
+    local codec="$1"
+    local format="$2"
+
+    echo "Generating number-videos/numbers-$num_frames-$codec.$format"
+
+    ffmpeg                                     \
+        -nostdin                               \
+        -v error                               \
+        -i "number-frames/$num_frames-%d.png"  \
+        -vcodec "$codec"                       \
+        "number-videos/numbers-$num_frames-$codec.$format"
+}
+
+generate_number_video vp9    mp4
+generate_number_video theora ogv
+generate_number_video flv1   flv
+generate_number_video mpeg4  mpeg
+generate_number_video h264   mp4
+generate_number_video vp9    webm
+generate_number_video wmv2   asf
+generate_number_video h263   3gp

--- a/scripts/generate-number-videos.sh
+++ b/scripts/generate-number-videos.sh
@@ -46,34 +46,27 @@ echo "Generating $num_frames number frames"
 # NOTE: The H.263 codec supports only a few specific resolutions. 352x288 is one of them.
 for i in $(seq 1 "$num_frames"); do
     generate_frame default $i 128 128
-    generate_frame h261    $i 352 288   # Resolutions supported by h261:             176x144, 352x288
     generate_frame h263    $i 352 288   # Resolutions supported by h263:     128x96, 176x144, 352x288,   704x576, 1408x1152
-    generate_frame dvvideo $i 720 576   # Resolutions supported by dvvideo: 720x480, 720x576, 960x720, 1280x1080, 1440x1080
 done
 
 # Tier 1: popular codecs
 generate_number_video default av1        mkv   # Alliance for Open Media AV1
 generate_number_video default cinepak    cpk   # Cinepak
-generate_number_video default dirac      drc   # Dirac
-generate_number_video default dirac      mkv
+generate_number_video default dirac      mkv   # Dirac
 generate_number_video default dirac      mp4
 generate_number_video default dirac      avi
 generate_number_video default flv1       flv   # FLV / Sorenson Spark / Sorenson H.263 (Flash Video)
 generate_number_video default flv1       mkv
 generate_number_video default flv1       avi
 generate_number_video h263    h263       3gp   # H.263 / H.263-1996, H.263+ / H.263-1998 / H.263 version 2
-generate_number_video h263    h263       h263
 generate_number_video default h264       mp4   # H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
-generate_number_video default h264       h264
 generate_number_video default h264       mkv
 generate_number_video default h264       avi
 generate_number_video default h264       flv
 generate_number_video default hevc       mp4   # H.265 / HEVC (High Efficiency Video Coding)
 generate_number_video default hevc       mkv
-generate_number_video default hevc       hevc
 generate_number_video default hevc       mpeg
-generate_number_video default mjpeg      mjpeg # Motion JPEG
-generate_number_video default mjpeg      avi
+generate_number_video default mjpeg      avi   # Motion JPEG
 generate_number_video default mjpeg      mov
 generate_number_video default mjpeg      mkv
 generate_number_video default mpeg1video mpeg  # MPEG-1 video
@@ -92,15 +85,11 @@ generate_number_video default wmv1       asf   # Windows Media Video 7
 generate_number_video default wmv2       asf   # Windows Media Video 8
 
 # Tier 2: some less popular codecs
-generate_number_video dvvideo dvvideo    dv    # DV (Digital Video)
-generate_number_video h261    h261       h261  # H.261
-generate_number_video h263    h263p      h263  # H.263+ / H.263-1998 / H.263 version 2
 generate_number_video default huffyuv    mkv   # HuffYUV
-generate_number_video default msmpeg4v2  mpeg  # MPEG-4 part 2 Microsoft variant version 2
-generate_number_video default msmpeg4v3  mpeg  # MPEG-4 part 2 Microsoft variant version 3
-generate_number_video default rawvideo   mkv   # raw video
-generate_number_video default rv10       rm    # RealVideo 1.0
-generate_number_video default rv20       rm    # RealVideo 2.0
+generate_number_video default msmpeg4v2  avi   # MPEG-4 part 2 Microsoft variant version 2
+generate_number_video default msmpeg4v2  wmv
+generate_number_video default msmpeg4v3  avi   # MPEG-4 part 2 Microsoft variant version 3
+generate_number_video default msmpeg4v3  wmv
 generate_number_video default svq1       mov   # Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
 generate_number_video default v210       avi   # Uncompressed 4:2:2 10-bit
 generate_number_video default v308       avi   # Uncompressed packed 4:4:4

--- a/scripts/generate-number-videos.sh
+++ b/scripts/generate-number-videos.sh
@@ -37,6 +37,7 @@ function generate_number_video {
         -v      error                                            \
         -i      "number-frames/$frame_prefix-$num_frames-%d.png" \
         -vcodec "$codec"                                         \
+        -g      25                                               \
         -strict -2                                               \
         "number-videos/numbers-$num_frames-$codec.$format"
 }

--- a/scripts/generate-number-videos.sh
+++ b/scripts/generate-number-videos.sh
@@ -3,7 +3,7 @@
 mkdir --parents number-frames/
 mkdir --parents number-videos/
 
-num_frames=100
+num_frames="$1"
 
 echo "Generating $num_frames number frames"
 

--- a/scripts/generate-number-videos.sh
+++ b/scripts/generate-number-videos.sh
@@ -4,7 +4,11 @@ mkdir --parents number-frames/
 mkdir --parents number-videos/
 
 num_frames="$1"
-gop_size=25
+gop_size="$2"    # GOP = Group of Pictures; each GOP starts with an I-frame
+
+if [[ "$gop_size" == "" ]]; then
+    gop_size=25
+fi
 
 function generate_frame {
     local frame_prefix="$1"

--- a/scripts/generate-number-videos.sh
+++ b/scripts/generate-number-videos.sh
@@ -53,6 +53,7 @@ echo "Generating $num_frames number frames with GOP size $gop_size"
 for i in $(seq 1 "$num_frames"); do
     generate_frame default $i 128 128
     generate_frame h263    $i 352 288   # Resolutions supported by h263:     128x96, 176x144, 352x288,   704x576, 1408x1152
+    generate_frame dvvideo $i 720 576   # Resolutions supported by dvvideo: 720x480, 720x576, 960x720, 1280x1080, 1440x1080
 done
 
 # Tier 1: popular codecs
@@ -103,3 +104,19 @@ generate_number_video default v408       avi   # Uncompressed packed QT 4:4:4:4
 generate_number_video default v410       avi   # Uncompressed 4:4:4 10-bit
 generate_number_video default y41p       avi   # Uncompressed YUV 4:1:1 12-bit
 generate_number_video default yuv4       avi   # Uncompressed packed 4:2:0
+
+# Tier 3: problematic codecs/containers.
+# Splitting, merging or transcoding most of them ends with an error.
+generate_number_video h263    h261      h261   # H.261
+generate_number_video h263    h263      h263
+generate_number_video h263    h263p     h263   # H.263+ / H.263-1998 / H.263 version 2
+generate_number_video default h264      h264
+generate_number_video default hevc      hevc
+generate_number_video default mjpeg     mjpeg
+generate_number_video default rv10      rm     # RealVideo 1.0
+generate_number_video default rv20      rm     # RealVideo 2.0
+generate_number_video default dirac     drc    #
+generate_number_video default msmpeg4v2 mpeg   # MPEG-4 part 2 Microsoft variant version 2
+generate_number_video default msmpeg4v3 mpeg   # MPEG-4 part 2 Microsoft variant version 3
+generate_number_video default rawvideo  mkv    # raw video
+generate_number_video dvvideo dvvideo   dv     # DV (Digital Video)

--- a/scripts/generate-number-videos.sh
+++ b/scripts/generate-number-videos.sh
@@ -45,7 +45,7 @@ echo "Generating $num_frames number frames"
 
 # NOTE: The H.263 codec supports only a few specific resolutions. 352x288 is one of them.
 for i in $(seq 1 "$num_frames"); do
-    generate_frame default $i 352 288
+    generate_frame default $i 128 128
 done
 
 generate_number_video default flv1       flv


### PR DESCRIPTION
A simple script for generating some of the videos I used for testing split&merge. The README file included in this pull request contains a comprehensive description and examples showing how to run it.

NOTE: This request is based on top of #1 and should be merged after it but if necessary, it could also be merged independently after a simple rebase and some minimal changes.