### PR TITLE
Segment splitter with separate audio

### DIFF
--- a/ffmpeg-segment-experiments/README.md
+++ b/ffmpeg-segment-experiments/README.md
@@ -56,3 +56,12 @@ Runs experiments with separate audio, not included in the 2019-03-08 report.
 ``` bash
 ./run-experiment-set.sh 5 input output ffmpeg-segment-separate-audio
 ```
+
+#### video-info
+Produces a report with basic information about the input files.
+
+``` bash
+./run-experiment-set.sh 5 input output video-info
+```
+
+It still runs a split/merge operation but only to produce intermediate files from which the `input_file_info_report` gathers the information.

--- a/ffmpeg-segment-experiments/README.md
+++ b/ffmpeg-segment-experiments/README.md
@@ -49,3 +49,10 @@ This directory also contains the manually created report with analysis of the re
         ./run-experiment-set.sh 5 input output ffmpeg-ss-and-concat-protocol-2019-03-08
         ```
     - Note: one failure interrupts all the experiments and prevents the report from being printed so it's recommended to use smaller batches of the input files and run the experiment set separately on each one.
+
+### Other experiment sets
+#### ffmpeg-segment-separate-audio
+Runs experiments with separate audio, not included in the 2019-03-08 report.
+``` bash
+./run-experiment-set.sh 5 input output ffmpeg-segment-separate-audio
+```

--- a/ffmpeg-segment-experiments/experiment-sets/ffmpeg-segment-separate-audio.sh
+++ b/ffmpeg-segment-experiments/experiment-sets/ffmpeg-segment-separate-audio.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+source functions/all.sh
+
+num_segments="$1"
+input_dir="$2"
+output_dir="$3"
+
+video_files="$(find "$input_dir" -mindepth 1 -maxdepth 1)"
+
+experiments=(
+    segment-split-separate-audio-only
+    segment-split-separate-audio-half-scale
+    segment-split-separate-audio-flv-convert
+)
+for experiment in ${experiments[@]}; do
+    run_experiment_on_all_videos "$num_segments" "$experiment" "$output_dir" "$video_files"
+done
+
+input_file_info_report       "$output_dir" segment-split-separate-audio-only
+
+frame_type_report_split_only "$output_dir" segment-split-separate-audio-only
+frame_type_report            "$output_dir" segment-split-separate-audio-half-scale
+frame_type_report            "$output_dir" segment-split-separate-audio-flv-convert
+
+timestamps_report            "$output_dir" segment-split-separate-audio-half-scale
+timestamps_report            "$output_dir" segment-split-separate-audio-flv-convert

--- a/ffmpeg-segment-experiments/experiment-sets/video-info.sh
+++ b/ffmpeg-segment-experiments/experiment-sets/video-info.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+source functions/all.sh
+
+num_segments="$1"
+input_dir="$2"
+output_dir="$3"
+
+video_files="$(find "$input_dir" -mindepth 1 -maxdepth 1)"
+
+experiments=(
+    segment-split-only
+)
+for experiment in ${experiments[@]}; do
+    run_experiment_on_all_videos "$num_segments" "$experiment" "$output_dir" "$video_files"
+done
+
+input_file_info_report "$output_dir" segment-split-only

--- a/ffmpeg-segment-experiments/experiments/segment-split-flv-convert.sh
+++ b/ffmpeg-segment-experiments/experiments/segment-split-flv-convert.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+source functions/all.sh
+
+num_segments="$1"
+video_file="$2"
+output_dir="$3"
+
+experiment_name="$(basename_without_extension "${BASH_SOURCE[0]}")"
+experiment_dir="$output_dir/$experiment_name/$(basename "$video_file")"
+
+init_experiment_dir       "$experiment_dir" "$video_file" flv
+split_input               "$experiment_dir" "split_with_ffmpeg_segment $num_segments"
+transcode_input           "$experiment_dir" "ffmpeg_transcode_with_codec flv1"
+transcode_segments        "$experiment_dir" "ffmpeg_transcode_with_codec flv1"
+merge_transcoded_segments "$experiment_dir" "merge_with_ffmpeg_concat_demuxer"
+
+dump_frame_types_for_experiment "$experiment_dir"

--- a/ffmpeg-segment-experiments/experiments/segment-split-separate-audio-flv-convert.sh
+++ b/ffmpeg-segment-experiments/experiments/segment-split-separate-audio-flv-convert.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+source functions/all.sh
+
+num_segments="$1"
+video_file="$2"
+output_dir="$3"
+
+experiment_name="$(basename_without_extension "${BASH_SOURCE[0]}")"
+experiment_dir="$output_dir/$experiment_name/$(basename "$video_file")"
+
+init_experiment_dir             "$experiment_dir" "$video_file" mkv
+extract_video_and_replace_input "$experiment_dir" "ffmpeg_extract_video_streams"
+split_input                     "$experiment_dir" "split_with_ffmpeg_segment $num_segments"
+transcode_input                 "$experiment_dir" "ffmpeg_transcode_with_codec flv1"
+transcode_segments              "$experiment_dir" "ffmpeg_transcode_with_codec flv1"
+merge_transcoded_segments       "$experiment_dir" "merge_with_ffmpeg_concat_demuxer"
+insert_video_and_replace_output "$experiment_dir" "ffmpeg_insert_video_streams"
+
+dump_frame_types_for_experiment "$experiment_dir"

--- a/ffmpeg-segment-experiments/experiments/segment-split-separate-audio-half-scale.sh
+++ b/ffmpeg-segment-experiments/experiments/segment-split-separate-audio-half-scale.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+source functions/all.sh
+
+num_segments="$1"
+video_file="$2"
+output_dir="$3"
+
+experiment_name="$(basename_without_extension "${BASH_SOURCE[0]}")"
+experiment_dir="$output_dir/$experiment_name/$(basename "$video_file")"
+
+init_experiment_dir             "$experiment_dir" "$video_file"
+extract_video_and_replace_input "$experiment_dir" "ffmpeg_extract_video_streams"
+split_input                     "$experiment_dir" "split_with_ffmpeg_segment $num_segments"
+transcode_input                 "$experiment_dir" "ffmpeg_scale 0.5"
+transcode_segments              "$experiment_dir" "ffmpeg_scale 0.5"
+merge_transcoded_segments       "$experiment_dir" "merge_with_ffmpeg_concat_demuxer"
+insert_video_and_replace_output "$experiment_dir" "ffmpeg_insert_video_streams"
+
+dump_frame_types_for_experiment "$experiment_dir"

--- a/ffmpeg-segment-experiments/experiments/segment-split-separate-audio-only.sh
+++ b/ffmpeg-segment-experiments/experiments/segment-split-separate-audio-only.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+source functions/all.sh
+
+num_segments="$1"
+video_file="$2"
+output_dir="$3"
+
+experiment_name="$(basename_without_extension "${BASH_SOURCE[0]}")"
+experiment_dir="$output_dir/$experiment_name/$(basename "$video_file")"
+
+init_experiment_dir             "$experiment_dir" "$video_file"
+extract_video_and_replace_input "$experiment_dir" "ffmpeg_extract_video_streams"
+split_input                     "$experiment_dir" "split_with_ffmpeg_segment $num_segments"
+merge_segments                  "$experiment_dir" "merge_with_ffmpeg_concat_demuxer"
+insert_video_and_replace_output "$experiment_dir" "ffmpeg_insert_video_streams"
+
+dump_frame_types_for_experiment "$experiment_dir"

--- a/ffmpeg-segment-experiments/functions/experiment-steps.sh
+++ b/ffmpeg-segment-experiments/functions/experiment-steps.sh
@@ -19,6 +19,50 @@ function init_experiment_dir {
 }
 
 
+function extract_video_and_replace_input {
+    local experiment_dir="$1"
+    local extract_command="$2"
+
+    local input_format="$(cat "$experiment_dir/input-format")"
+    local input_file="$experiment_dir/input.$input_format"
+    local input_file_all="$experiment_dir/input-all.$input_format"
+    local input_file_video="$experiment_dir/input-video.$input_format"
+
+    mv            "$input_file"              "$input_file_all"
+    ln --symbolic "input-video.$input_format" "$input_file"
+
+    $extract_command      \
+        "$input_file_all" \
+        "$input_file_video"
+}
+
+
+function insert_video_and_replace_output {
+    local experiment_dir="$1"
+    local insert_command="$2"
+
+    local input_format="$(cat "$experiment_dir/input-format")"
+    local input_file="$experiment_dir/input.$input_format"
+    local input_file_all="$experiment_dir/input-all.$input_format"
+
+    local output_format="$(cat "$experiment_dir/output-format")"
+    local output_file="$experiment_dir/merged.$output_format"
+    local output_file_all="$experiment_dir/merged-all.$output_format"
+    local output_file_video="$experiment_dir/merged-video.$output_format"
+
+    mv            "$output_file"              "$output_file_video"
+    ln --symbolic "merged-all.$output_format" "$output_file"
+
+    $insert_command          \
+        "$input_file_all"    \
+        "$output_file_video" \
+        "$output_file_all"
+
+    # Now we can also make the input link point at the original input video with all streams
+    ln --symbolic --force "input-all.$input_format" "$input_file"
+}
+
+
 function split_input {
     local experiment_dir="$1"
     local split_command="$2"

--- a/ffmpeg-segment-experiments/functions/video-info.sh
+++ b/ffmpeg-segment-experiments/functions/video-info.sh
@@ -113,3 +113,22 @@ function load_frame_types_for_video {
 
     cat "$(strip_extension "$video_file")-frame-types.txt"
 }
+
+
+function count_streams {
+    codec_type="$1"
+    input_file="$2"
+
+    num_streams=$(ffprobe_show_entries "$input_file" format=nb_streams)
+
+    result=0
+    for i in $(seq 0 $(( $num_streams - 1 ))); do
+        current_codec_type="$(ffprobe_get_stream_attribute "$input_file" $i codec_type)"
+
+        if [[ "$current_codec_type" == "$codec_type" ]]; then
+            result=$(( $result + 1 ))
+        fi
+    done
+
+    printf "%d" $result
+}


### PR DESCRIPTION
This pull request adds experiments which extract the audio track before splitting the video and insert it back after merge. They are not included in the report submitted in #3.

The transcoding in the new experiments is done using `flv1` codec rather than `vp9` - it's much faster as my benchmarks have shown, works with all our files and my results show that it makes no real difference in the results.

It also adds one trvial experiment set which can be used to get only the information about the input files (until now I always needed to comment-out a bunch of stuff to get this info quickly).

This is the last bit of experimenting I did before switching to implementing this method of transcoding in Golem's `CGI/transcoding/master` branch.

This pull request depends on #3 and must be merged after it.